### PR TITLE
Issue/249 - Assets: Just-in-Time enqueueueueing.

### DIFF
--- a/sugar-calendar/includes/themes/legacy/hooks.php
+++ b/sugar-calendar/includes/themes/legacy/hooks.php
@@ -44,4 +44,8 @@ if ( wp_using_themes() || wp_doing_ajax() ) {
 	add_action( 'sc_before_event_content', 'sc_add_event_details'     );
 	add_action( 'sc_event_details',        'sc_add_date_time_details' );
 	add_action( 'sc_event_details',        'sc_add_location_details'  );
+
+	// Just-in-Time Assets
+	add_action( 'sc_before_calendar',    'sc_enqueue_assets' );
+	add_action( 'sc_before_events_list', 'sc_enqueue_assets' );
 }

--- a/sugar-calendar/includes/themes/legacy/scripts.php
+++ b/sugar-calendar/includes/themes/legacy/scripts.php
@@ -44,6 +44,20 @@ function sc_register_assets() {
 }
 
 /**
+ * Enqueue front-end assets.
+ *
+ * @since 2.3.0
+ */
+function sc_enqueue_assets() {
+
+	// Scripts
+	sc_enqueue_scripts();
+
+	// Styles
+	sc_enqueue_styles();
+}
+
+/**
  * Load front-end scripts.
  *
  * @since 1.0.0
@@ -60,8 +74,7 @@ function sc_load_front_end_scripts() {
 		||
 		sc_content_has_shortcodes()
 	) {
-		sc_enqueue_scripts();
-		sc_enqueue_styles();
+		sc_enqueue_assets();
 	}
 }
 
@@ -126,8 +139,7 @@ function sc_enqueue_if_block_has_shortcodes( $content = '' ) {
 
 	// Check the block content for a shortcode
 	if ( sc_content_has_shortcodes( $content ) ) {
-		sc_enqueue_scripts();
-		sc_enqueue_styles();
+		sc_enqueue_assets();
 	}
 
 	// Return the content, unchanged


### PR DESCRIPTION
This change re-enqueues assets anytime calendar & list functions are called, in addition to `wp_enqueue_scripts`.

This may cause issues for folks who are hoping to dequeue our core styling, but it does improve support for theme frameworks and site builders.

See #249.