### PR TITLE
Issue/48 - Introduce sugar_calendar_get_events_list()

### DIFF
--- a/sugar-calendar/includes/common/hooks.php
+++ b/sugar-calendar/includes/common/hooks.php
@@ -34,3 +34,6 @@ add_action( 'sc_parse_events_query',   'sugar_calendar_pre_get_events_by_taxonom
 // Default Calendar
 add_filter( 'pre_option_default_sc_event_category',      'sugar_calendar_pre_get_default_calendar_option', 10, 3 );
 add_filter( 'pre_option_default_term_sc_event_category', 'sugar_calendar_pre_get_default_calendar_option', 10, 3 );
+
+// Clean list caches on Event new/update
+add_action( 'save_post', 'sugar_calendar_clean_events_list_cache' );

--- a/sugar-calendar/includes/common/time.php
+++ b/sugar-calendar/includes/common/time.php
@@ -251,6 +251,42 @@ function sugar_calendar_human_diff_time( $older_date, $newer_date = false ) {
 }
 
 /**
+ * Round a timestamp to its nearest interval.
+ *
+ * By default, rounds current time to nearest 15 minute interval.
+ *
+ * @since 2.3.0
+ *
+ * @param mixed  $timestamp Optional. Default null.
+ * @param string $interval  Optional. Default 'PT900S'.
+ * @param string $timezone1 Optional. Default null.
+ * @param string $timezone2 Optional. Default null.
+ * @param string $direction Optional. Default "up".
+ *
+ * @return DateTime Default inside current 15 minute interval.
+ */
+function sugar_calendar_round_time( $timestamp = null, $interval = 'PT900S', $timezone1 = null, $timezone2 = null, $direction = 'up' ) {
+
+	// Calculate nearest expiration
+	$lifetime = new DateInterval( $interval );
+	$seconds  = $lifetime->format( '%s' );
+
+	// Get the DateTime object
+	$dt = sugar_calendar_get_datetime_object( $timestamp, $timezone1, $timezone2 );
+
+	// Maths the timestamp to the nearest interval
+	$retval = $dt->setTimestamp( $seconds * (int) ceil( $dt->getTimestamp() / $seconds ) );
+
+	// Add interval if rounding up
+	if ( 'down' === $direction ) {
+		$retval->sub( $lifetime );
+	}
+
+	// Filter & return
+	return apply_filters( 'sugar_calendar_round_time', $retval, $timestamp, $interval, $timezone1, $timezone2, $direction );
+}
+
+/**
  * Return array of recurrence types
  *
  * @since 2.0

--- a/sugar-calendar/includes/common/time.php
+++ b/sugar-calendar/includes/common/time.php
@@ -253,7 +253,7 @@ function sugar_calendar_human_diff_time( $older_date, $newer_date = false ) {
 /**
  * Round a timestamp to its nearest interval.
  *
- * By default, rounds current time to nearest 15 minute interval.
+ * By default, rounds current time up to nearest 15 minute interval.
  *
  * @since 2.3.0
  *
@@ -263,7 +263,7 @@ function sugar_calendar_human_diff_time( $older_date, $newer_date = false ) {
  * @param string $timezone2 Optional. Default null.
  * @param string $direction Optional. Default "up".
  *
- * @return DateTime Default inside current 15 minute interval.
+ * @return DateTime Default current time up to nearest 15 minute interval.
  */
 function sugar_calendar_round_time( $timestamp = null, $interval = 'PT900S', $timezone1 = null, $timezone2 = null, $direction = 'up' ) {
 

--- a/sugar-calendar/includes/events/functions.php
+++ b/sugar-calendar/includes/events/functions.php
@@ -629,14 +629,14 @@ function sugar_calendar_get_events_list( $args = array(), $query_args = array() 
 		'spread'   => 'P100Y',    // 100 years
 		'expires'  => 'PT900S',   //  15 minutes
 		'sow'      => sugar_calendar_get_user_preference( 'sc_start_of_week' ),
-		'tz'       => sugar_calendar_get_user_preference( 'sc_timezone' ),
+		'timezone' => sugar_calendar_get_user_preference( 'sc_timezone' ),
 	) );
 
 	// Get the current request time
 	$now = sugar_calendar_get_request_time();
 
 	// Add rounded value to args, for cache key below
-	$r['round'] = sugar_calendar_round_time( $now, $r['expires'], 'UTC', $r['tz'] );
+	$r['round'] = sugar_calendar_round_time( $now, $r['expires'], 'UTC', $r['timezone'] );
 
 	// Turn parsed args into a unique string used as the cache key
 	$key = md5( serialize( $r ) );
@@ -701,7 +701,7 @@ function sugar_calendar_get_events_list( $args = array(), $query_args = array() 
 			$events,
 			$after,
 			$before,
-			$r['tz'],
+			$r['timezone'],
 			$r['sow']
 		);
 

--- a/sugar-calendar/includes/events/functions.php
+++ b/sugar-calendar/includes/events/functions.php
@@ -623,13 +623,13 @@ function sugar_calendar_get_events_list( $args = array(), $query_args = array() 
 
 	// Parse args
 	$r = wp_parse_args( $args, array(
-		'order'    => 'DESC',
-		'number'   => 5,
-		'display'  => 'upcoming',
-		'spread'   => 'P100Y',    // 100 years
-		'expires'  => 'PT900S',   //  15 minutes
-		'sow'      => sugar_calendar_get_user_preference( 'sc_start_of_week' ),
-		'timezone' => sugar_calendar_get_user_preference( 'sc_timezone' ),
+		'order'         => 'DESC',
+		'number'        => 5,
+		'display'       => 'upcoming',
+		'spread'        => 'P100Y',    // 100 years
+		'expires'       => 'PT900S',   //  15 minutes
+		'start_of_week' => sugar_calendar_get_user_preference( 'sc_start_of_week' ),
+		'timezone'      => sugar_calendar_get_user_preference( 'sc_timezone' ),
 	) );
 
 	// Get the current request time
@@ -702,7 +702,7 @@ function sugar_calendar_get_events_list( $args = array(), $query_args = array() 
 			$after,
 			$before,
 			$r['timezone'],
-			$r['sow']
+			$r['start_of_week']
 		);
 
 		// Default events list


### PR DESCRIPTION
This PR introduces a new function: `sugar_calendar_get_events_list()`, and uses it to compile a list of of Events (including recurring Event sequences) according to the number, order, and display parameters of the original `sc_get_events_list()` function.

It also introduces an extremely primitive but necessary cache layer that saves the compiled results into an option with the key `sc_events_list_cache`. This option is an array, keyed with an `md5` hash of the above parameters.

This cache is cleaned anytime a Post Type that supports `events` is saved, and is currently intentionally overzealous in doing so. Future iterations of this functionality could more tightly target specific parameters, but for the time being it's helpful to purge and recompile all lists at the same time.

This PR is the first of several that I suggest be merged into the 2.3.0 branch to help iterate on solving #48. It does not fix it entirely; more simply, it introduces the function that future PRs should use to list Events eventually, and uses widgets/shortcodes as the proof of concept.

See #48.