### PR TITLE
Issue/248 - CPT/Taxos: unwind deep integration.

### DIFF
--- a/sugar-calendar/includes/admin/assets.php
+++ b/sugar-calendar/includes/admin/assets.php
@@ -104,7 +104,7 @@ function enqueue() {
 	}
 
 	// Events Pages
-	if ( sugar_calendar_admin_is_events_page() ) {
+	if ( sugar_calendar_admin_is_assets_page() ) {
 
 		// General
 		wp_enqueue_script( 'sugar_calendar_admin_general' );

--- a/sugar-calendar/includes/admin/general.php
+++ b/sugar-calendar/includes/admin/general.php
@@ -80,12 +80,7 @@ function sugar_calendar_admin_is_events_page() {
 
 	if (
 
-		// Add if the event post type
-		post_type_supports( $screen->post_type, 'events' )
-
-		||
-
-		// Or if Events pages
+		// If Events pages
 		sugar_calendar_get_admin_page_id() === $screen->id
 	) {
 		return true;
@@ -107,7 +102,7 @@ function sugar_calendar_admin_is_taxonomy_page() {
 	if (
 
 		// Add if the event post type
-		post_type_supports( $screen->post_type, 'events' )
+		sugar_calendar_is_supported_type( $screen->post_type )
 
 		&&
 
@@ -117,12 +112,34 @@ function sugar_calendar_admin_is_taxonomy_page() {
 		&&
 
 		// And is supported Taxonomy
-		in_array( $screen->taxonomy, sugar_calendar_get_object_taxonomies(), true )
+		$screen->taxonomy === sugar_calendar_get_calendar_taxonomy_id()
 	) {
 		return true;
 	}
 
 	return false;
+}
+
+/**
+ * Is this an admin page that requires assets to be enqueued?
+ *
+ * @since 2.3.0
+ *
+ * @return bool
+ */
+function sugar_calendar_admin_is_assets_page() {
+	$screen = get_current_screen();
+
+	return
+		sugar_calendar_admin_is_events_page()
+
+		||
+
+		sugar_calendar_admin_is_taxonomy_page()
+
+		||
+
+		sugar_calendar_is_supported_type( $screen->post_type );
 }
 
 /**

--- a/sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php
+++ b/sugar-calendar/includes/admin/list-tables/class-wp-list-table-base.php
@@ -1453,7 +1453,7 @@ class Base_List_Table extends \WP_List_Table {
 	protected function all_query_args( $args = array() ) {
 
 		// Maybe add `post` to to object_type's to query for
-		if ( post_type_supports( $this->get_screen_post_type(), 'events' ) ) {
+		if ( sugar_calendar_is_supported_type( $this->get_screen_post_type() ) ) {
 			$args['object_type'] = ! empty( $args['object_type'] )
 				? array_unshift( $args['object_type'], 'post' )
 				: array( 'post' );

--- a/sugar-calendar/includes/admin/menu.php
+++ b/sugar-calendar/includes/admin/menu.php
@@ -112,7 +112,7 @@ function fix_menu_highlight() {
 	global $parent_file, $submenu_file, $pagenow;
 
 	// Highlight both, since they're the same thing.
-	if ( sugar_calendar_admin_is_events_page() ) {
+	if ( sugar_calendar_admin_is_events_page() || sugar_calendar_admin_is_taxonomy_page() ) {
 
 		// Always set the parent file to the main menu
 		$parent_file  = 'sugar-calendar';
@@ -234,7 +234,7 @@ function calendar_page() {
 function body_class( $class = '' ) {
 
 	// Add class if in an admin page
-	if ( sugar_calendar_admin_is_events_page() ) {
+	if ( sugar_calendar_is_admin() ) {
 		$class .= ' sugar-calendar';
 	}
 

--- a/sugar-calendar/includes/admin/meta-boxes.php
+++ b/sugar-calendar/includes/admin/meta-boxes.php
@@ -233,7 +233,7 @@ function can_save_meta_box( $object_id = 0, $object = null ) {
 		$post_type = get_post_type( $object_id );
 
 		// Only save event metadata to supported post types
-		if ( ! post_type_supports( $post_type, 'events' ) ) {
+		if ( sugar_calendar_is_supported_type( $post_type ) ) {
 			return $retval;
 		}
 

--- a/sugar-calendar/includes/admin/meta-boxes.php
+++ b/sugar-calendar/includes/admin/meta-boxes.php
@@ -233,7 +233,7 @@ function can_save_meta_box( $object_id = 0, $object = null ) {
 		$post_type = get_post_type( $object_id );
 
 		// Only save event metadata to supported post types
-		if ( sugar_calendar_is_supported_type( $post_type ) ) {
+		if ( ! sugar_calendar_is_supported_type( $post_type ) ) {
 			return $retval;
 		}
 

--- a/sugar-calendar/includes/admin/nav.php
+++ b/sugar-calendar/includes/admin/nav.php
@@ -246,7 +246,7 @@ function taxonomy_tabs() {
 
 	// Get taxonomies
 	$taxonomy   = sanitize_key( $taxnow );
-	$post_type  = sugar_calendar_allowed_post_types();
+	$post_type  = sugar_calendar_get_event_post_type_id();
 	$taxonomies = sugar_calendar_get_object_taxonomies( $post_type );
 
 	// Bail if current taxonomy is not an event taxonomy

--- a/sugar-calendar/includes/admin/posts.php
+++ b/sugar-calendar/includes/admin/posts.php
@@ -102,7 +102,7 @@ function updated_messages( $messages = array() ) {
 function hide_quick_bulk_edit() {
 
 	// Bail if not an event post type
-	if ( ! post_type_supports( get_current_screen()->post_type, 'events' ) ) {
+	if ( ! sugar_calendar_is_supported_type( get_current_screen()->post_type ) ) {
 		return;
 	}
 
@@ -145,7 +145,7 @@ function redirect_old_post_type() {
 		$args = array();
 
 		// Get allowed keys
-		$taxos = sugar_calendar_get_object_taxonomies();
+		$taxos = (array) sugar_calendar_get_calendar_taxonomy_id();
 
 		// Loop through taxonomies looking for terms
 		if ( ! empty( $taxos ) ) {

--- a/sugar-calendar/includes/events/functions.php
+++ b/sugar-calendar/includes/events/functions.php
@@ -801,7 +801,7 @@ function sugar_calendar_clean_events_list_cache( $post_id = 0 ) {
 	$post_type = get_post_type( $post_id );
 
 	// Bail if post-type does not support events
-	if ( ! post_type_supports( $post_type, 'events' ) ) {
+	if ( ! sugar_calendar_is_supported_type( $post_type ) ) {
 		return;
 	}
 

--- a/sugar-calendar/includes/post/types.php
+++ b/sugar-calendar/includes/post/types.php
@@ -47,6 +47,19 @@ function sugar_calendar_allowed_post_types() {
 }
 
 /**
+ * Does a specific Post Type ID support Events?
+ *
+ * @since 2.3.0
+ *
+ * @param string $post_type
+ *
+ * @return bool
+ */
+function sugar_calendar_is_supported_type( $post_type = '' ) {
+	return post_type_supports( $post_type, 'events' );
+}
+
+/**
  * Register the Event post types
  *
  * If you want to manipulate these arguments, use the `register_post_type_args`


### PR DESCRIPTION
This was only partially working, and after further review was a bit too aggressive with everything that it attempted to rearrange.

This commit introduces sugar_calendar_admin_is_assets_page() and sugar_calendar_is_supported_type() helper functions, and uses them where helpful.

This PR removes the way that supported post types (other than "sc_events") would be redirected to the main admin area calendar. It will soon explore a better way.

See #248 